### PR TITLE
FI GlobalIPC aggregate

### DIFF
--- a/analyses/malawi/notebooks/GIPC_erroradm0aggr.ipynb
+++ b/analyses/malawi/notebooks/GIPC_erroradm0aggr.ipynb
@@ -5,7 +5,9 @@
    "metadata": {},
    "source": [
     "## Disreperancy Global IPC aggregation methods\n",
-    "For some dates different results are gained when calculating the numbers on admin0 and admin1 level in different way. Since the numbers are directly reported in the excel sheet on admin0 level we can use those. Simeltaneously we could sum all the numbers reported on admin2 level and this should give the same results. However, they don't match. This notebook does a short exploration of where the differences occur"
+    "For some dates different results are gained when calculating the numbers on admin0 and admin1 level in different way. Since the numbers are directly reported in the excel sheet on admin0 level we can use those. Simeltaneously we could sum all the numbers reported on admin2 level and this should give the same results. However, they don't match. This notebook does a short exploration of where the differences occur\n",
+    "\n",
+    "We choose to aggregate the numbers from admin2 instead of using those reported directly at admin1 and admin0. This is done to keep consistency across the admin levels, and because we cannot fully explain where the differences come from. Simeltaneously, we will ask the country team if there is a strong preference, especially since the "
    ]
   },
   {

--- a/indicators/food_insecurity/config.py
+++ b/indicators/food_insecurity/config.py
@@ -90,9 +90,9 @@ class Config:
     GLOBALIPC_FILENAME_PROCESSED="{country}_globalipc_admin{admin_level}{suffix}.csv"
     #Analysis name, Country Population, % of total county Pop, Area Phase are not being used in our current analysis so not mapping them
     # Not entirely sure if Area always equals Admin2 regions
-    GLOBALIPC_COLUMNNAME_MAPPING = {'Country':'ADMIN0','Level 1 Name':'ADMIN1','Area':'ADMIN2','Area ID':'ADMIN2_ID','Date of Analysis':'date','#':'pop_CS','Analysis Period':"CS_val",'#.1':'CS_1','%':'perc_CS_1','#.2':'CS_2', '%.1':'perc_CS_2', '#.3':'CS_3', '%.2':'perc_CS_3',
-       '#.4':'CS_4', '%.3':'perc_CS_4', '#.5':'CS_5','%.4':'perc_CS_5', '#.6':'CS_3p', '%.5':'perc_CS_3p', '#.7':'pop_ML1','Analysis Period.1':'ML1_val', '#.8':'ML1_1',
+    GLOBALIPC_COLUMNNAME_MAPPING = {'Country':'ADMIN0','Level 1 Name':'ADMIN1','Area':'ADMIN2','Area ID':'ADMIN2_ID','Date of Analysis':'date','#':'reported_pop_CS','Analysis Period':"CS_val",'#.1':'CS_1','%':'perc_CS_1','#.2':'CS_2', '%.1':'perc_CS_2', '#.3':'CS_3', '%.2':'perc_CS_3',
+       '#.4':'CS_4', '%.3':'perc_CS_4', '#.5':'CS_5','%.4':'perc_CS_5', '#.6':'CS_3p', '%.5':'perc_CS_3p', '#.7':'reported_pop_ML1','Analysis Period.1':'ML1_val', '#.8':'ML1_1',
        '%.6':'perc_ML1_1', '#.9':'ML1_2', '%.7':'perc_ML1_2', '#.10':'ML1_3', '%.8':'perc_ML1_3', '#.11':'ML1_4', '%.9':'perc_ML1_4', '#.12':'ML1_5', '%.10':'perc_ML1_5',
-       '#.13':'ML1_3p', '%.11':'perc_ML1_3p','#.14':'pop_ML2','Analysis Period.2':'ML2_val','#.15':"ML2_1", '%.12':'perc_ML2_1', '#.16':'ML2_2', '%.13':'perc_ML2_2', '#.17':'ML2_3', '%.14':'perc_ML2_3',
+       '#.13':'ML1_3p', '%.11':'perc_ML1_3p','#.14':'reported_pop_ML2','Analysis Period.2':'ML2_val','#.15':"ML2_1", '%.12':'perc_ML2_1', '#.16':'ML2_2', '%.13':'perc_ML2_2', '#.17':'ML2_3', '%.14':'perc_ML2_3',
        '#.18':'ML2_4', '%.15':'perc_ML2_4', '#.19':'ML2_5', '%.16':'perc_ML2_5', '#.20':'ML2_3p', '%.17':'perc_ML2_3p'}
 

--- a/indicators/food_insecurity/process_globalipc.py
+++ b/indicators/food_insecurity/process_globalipc.py
@@ -54,6 +54,48 @@ def compare_adm_names(df,country,config,parameters,admin_level):
             f" {missing_boundgipc}"
         )
 
+def test_mismatch_adminlevels(df_agg,df_precalc,admin_level,country, config):
+    #TODO: prettify this function
+    """
+    There might be a mismatch between different levels of reporting on admin0 and admin1 level.
+    The method we use is to compute the totals by aggregation of adm2 but raise a warning if doesn't match with reported adm0/1 numbers to make user aware
+    But the numbers on admin0 and admin1 level are also reported directly
+    This function compares the two methods of reporting and raises a warning if there is more than 5% difference between them
+    We only raise a warning to make the user aware, but continue to use the aggregation from adm2 methodology
+    Args:
+        df_agg (pd.DataFrame): dataframe containing the data on admin_level aggregated from admin2
+        df_precalc (pd.DataFrame): dataframe containing the data directly reported on admin_level
+        admin_level (int): integer indicating admin level of interest
+        country (str): name of country of interest
+        config (Config): Config class
+    """
+    if admin_level==0:
+        df_precalc = df_precalc[df_precalc[config.ADMIN0_COL].str.lower().str.match(f"{country.lower()}:")]
+    elif admin_level==1:
+
+        df_precalc = df_precalc[~df_precalc[config.ADMIN0_COL].str.lower().str.contains(country.lower())]
+        df_agg = df_agg.drop(config.ADMIN0_COL, axis=1)
+        df_agg=df_agg.rename(columns={config.ADMIN1_COL: config.ADMIN0_COL})
+    #no aggregation for adm2 so tests don't make sense in that case
+    else:
+        return None
+    if not df_precalc.empty and not df_agg.empty:
+        df_merge = df_agg.merge(df_precalc, on=["date", config.ADMIN0_COL], suffixes=("_agg", "_precalc"))
+        #only look at population and perc_ipc3+ for now, could add more
+        match_cols = [f"pop_{p}" for p in config.IPC_PERIOD_NAMES] + [f"perc_{p}_3p" for p in config.IPC_PERIOD_NAMES]
+        for c in match_cols:
+            if "perc" in c:
+                df_notmatch = df_merge[abs(df_merge[f"{c}_agg"] - df_merge[f"{c}_precalc"]) > 5]
+            else:
+                df_notmatch = df_merge[abs((df_merge[f"{c}_agg"] - df_merge[f"{c}_precalc"]) / df_merge[f"{c}_precalc"]) > 0.05]
+            if not df_notmatch.empty:
+                dateadm_notmatch = df_notmatch.set_index(["date", config.ADMIN0_COL]).index.unique()
+                dateadm_notmatch = dateadm_notmatch.sort_values()
+                dateadm_notmatch_str = ",".join([f"[{da[0].strftime('%m-%Y')},{da[1]}]" for da in dateadm_notmatch])
+                logger.warning(
+                    f"{c} reported on admin{admin_level} and aggregated from admin2 to {admin_level} differs by more than 5% "
+                    f"for the following date-admin{admin_level} combinations: {dateadm_notmatch_str}")
+
 def aggregate_adminlevel(df_ipc,admin_level,country,config):
     """
     Aggregate df_ipc to admin_level
@@ -61,32 +103,33 @@ def aggregate_adminlevel(df_ipc,admin_level,country,config):
         df_ipc (pd.Dataframe): dataframe containing the data and the admin_level column
         admin_level (int): integer indicating which admin level to aggregate to
         country (str): name of country of interest
-        config (Config): Config class, if None initialize empty one
+        config (Config): Config class
 
     Returns:
         df_ipc_agg (pd.DataFrame): dataframe with data aggregated to admin_level
     """
+    # we assume that the admin2 column is nan for rows where adm1/0 sums are reported.
+    # Thus, this enable us to compute the total adm1/0s by summing the adm2s
+    # From empirical testing it was shown that the aggregations from adm2 to adm1/0 don't always equal the reported adm1/0 sums
+    # Since one methodology had to be chosen, we chose to always use the adm2 numbers as basis and aggregate from here
+    # This enables us to be consistent across admin levels
+    # The reasons for disagreement are not entirely clear. One cause is the inclusion of IDPs on adm1 and not on adm2, but this doesn't explain all the differences
+    df_ipc_adm2=df_ipc[(df_ipc["date"].notnull()) & (df_ipc[f"ADMIN2"].notnull())]
     if admin_level == 0:
-        #TODO: decide on method of admin0 aggregation
-        #data of countries we have worked so far with enables us to aggregate to admin0 level with two methods
-        #one is to take all the adm2 values and group them by date
-        #the other is to use the already aggregated numbers on admin0 level that are present in the raw data
-        #in theory they should give the same results, but in practice they dont... (for MWI and SOM)
-        #TODO: aggregate from admin2 and use the other two methods only to raise warning if mismatch
-        df_ipc_adm0_group = df_ipc[df_ipc[config.ADMIN0_COL].str.lower().str.fullmatch(country.lower())].groupby([config.ADMIN0_COL,"date"],as_index=False).sum()
-        df_ipc_adm0_precalc = df_ipc[df_ipc[config.ADMIN0_COL].str.lower().str.match(f"{country.lower()}:")]
-        #TODO: remove once aggregation method has been decided
-        print(df_ipc_adm0_precalc[["ADMIN0","date","CS_1"]].sort_values("date"))
-        print(df_ipc_adm0_group[["ADMIN0","date","CS_1"]].sort_values("date"))
-        df_ipc_agg = df_ipc_adm0_precalc
+        df_ipc_agg = df_ipc_adm2.groupby("date",as_index=False).sum()
+        df_ipc_agg[config.ADMIN0_COL] = country
+
 
     elif admin_level == 1:
-        #TODO: aggregate from admin2 and use the other method only to raise warning if mismatch
-        df_ipc_agg = df_ipc.groupby([config.ADMIN1_COL, "date"], as_index=False).sum()
+        # we assume that the admin1_col contains the name of the adm1 region for each admin2,
+        # but that the summed numbers of adm1s are given in the adm0 column and thus not in the admin1
+        # thus we can groupby the admin1 col to get the sums of the adm2s per adm1
+        df_ipc_agg = df_ipc_adm2.groupby([config.ADMIN1_COL, "date"], as_index=False).sum()
         df_ipc_agg[config.ADMIN0_COL] = country
 
     elif admin_level == 2:
-        df_ipc_agg = df_ipc.groupby(["date", config.ADMIN1_COL, config.ADMIN2_COL], dropna=False, as_index=False).sum()
+        #it can occur that an adm2 name occurs in two adm1s, hence groupby adm1-adm2 combination and not only adm2
+        df_ipc_agg = df_ipc_adm2.groupby(["date", config.ADMIN1_COL, config.ADMIN2_COL], dropna=False, as_index=False).sum()
         df_ipc_agg[config.ADMIN0_COL] = country
     else:
         logger.error(f"Admin level {admin_level} has not been implemented")
@@ -94,27 +137,46 @@ def aggregate_adminlevel(df_ipc,admin_level,country,config):
     return df_ipc_agg
 
 def compute_population_admin(df,admin_level,config):
-    print(df[["date","reported_pop_CS","reported_pop_ML1","reported_pop_ML2"]])
+    """
+    Compute the population assigned to an IPC phase per admin-date combination
+    Global IPC reports the population that is analysed but this reported number doesn't always equal the sum of population over all the ipc phases
+    Why there is this discrepancy, isn't entirely clear. But since the threshold are based on percentage of the population in each phase,
+    we want to make sure the total analysed population equals the sum of the population of all ipc phases.
+    Args:
+        df (pd.DataFrame): dataframe containing the populatoin per ipc phase and the reported total population
+        admin_level (int): integer indicating which admin level to aggregate to
+        config (Config): Config class
+    Returns:
+        df (pd.DataFrame): input dataframe with column per period containing the sum of population of all IPC phases
+    """
+
     for period in config.IPC_PERIOD_NAMES:
         #with min_count=1 NaN is returned instead of 0 if all values are NaN
         df[f"pop_{period}"]=df[[f"{period}_{i}" for i in range(1, 6)]].sum(axis=1,min_count=1)
-        df_notmatch = df[abs((df[f"pop_{period}"]-df[f"reported_pop_{period}"])/df[f"reported_pop_{period}"])>0.05]
-        if not df_notmatch.empty:
-            dateadm_notmatch = df_notmatch.set_index(["date",f"ADMIN{admin_level}"]).index.unique()
-            dateadm_notmatch = dateadm_notmatch.sort_values()
-            # df_notmatch_numbers =
-            cols = ["date",f"ADMIN{admin_level}",f"pop_{period}",f"reported_pop_{period}"]
-            print([",".join("{}:{}".format(*t) for t in zip(cols, row)) for _, row in df_notmatch[cols].iterrows()])
-            dateadm_notmatch_str = ",".join([f"[{da[0].strftime('%m-%Y')},{da[1]}]" for da in dateadm_notmatch])
-            logger.warning(f"{period}: Not matching population numbers on the following date-admin{admin_level} combinations: {dateadm_notmatch_str}")
-    # neg_dates = df[df[c] < 0].index.unique()
-    # neg_dates = neg_dates.sort_values()
-    # neg_dates_str = ",".join([n.strftime("%d-%m-%Y") for n in neg_dates])
-    # logger.warning(f'{data_name}: Negative value in column {c} on {neg_dates_str}')
+        #raise a warning if the reported numbers and the sum over the ipc phases are not equal.
+        #only do this for admin2 since we aggregate from those
+        #user doesn't have to do anything with this information, but good to know as a quality indicator of the data
+        if admin_level==2:
+            df_notmatch = df[abs((df[f"pop_{period}"]-df[f"reported_pop_{period}"])/df[f"reported_pop_{period}"])>0.05]
+            df_notmatch = df_notmatch[(df_notmatch[config.ADMIN2_COL].notnull())]
+            if not df_notmatch.empty:
+                dateadm_notmatch = df_notmatch.set_index(["date",f"ADMIN{admin_level}"]).index.unique()
+                dateadm_notmatch = dateadm_notmatch.sort_values()
+                dateadm_notmatch_str = ",".join([f"[{da[0].strftime('%m-%Y')},{da[1]}]" for da in dateadm_notmatch])
+                logger.warning(f"{period}: The sum of population in the ipc phases differs from the reported total population by more than 5% "
+                               f"for the following date-admin{admin_level} combinations in {period}: {dateadm_notmatch_str}")
     return df
 
 
 def download_globalipc(country,config,parameters,output_dir):
+    """
+    Retrieve the Global IPC data from their Population Tracking Tool and save to output_file
+    Args:
+        country (str): name of country of interest
+        config (Config): Config class
+        parameters (dict): dict with parameters parsed from config
+        output_dir (str): path to directory the file should be saved to
+    """
     #create directory if doesn't exist
     Path(output_dir).mkdir(parents=True, exist_ok=True)
     min_year=2010 #first year to retrieve data for. Doesn't matter if global ipc only started including data for later years
@@ -133,7 +195,7 @@ def process_globalipc(country, admin_level, config, parameters,ipc_dir):
     Args:
         country (str): name of country of interest
         admin_level (int): integer indicating which admin level to aggregate to
-        config (Config): Config class, if None initialize empty one
+        config (Config): Config class
         parameters (dict): dict with parameters parsed from config
         ipc_dir (str): absolute path to directory containing the raw ipc data
 
@@ -156,40 +218,48 @@ def process_globalipc(country, admin_level, config, parameters,ipc_dir):
     #write to file such that user can check if column names are correct
     df_ipc.to_excel(os.path.join(ipc_dir,config.GLOBALIPC_FILENAME_NEWCOLNAMES.format(country=country)))
 
-    # remove rows with nan date and nan adm value
-    df_ipc = df_ipc[
-        (df_ipc["date"].notnull()) & (df_ipc[f"ADMIN{admin_level}"].notnull())
-        ]
+    # remove rows with nan date, these often include textual information in other formats
+    df_ipc = df_ipc[df_ipc["date"].notnull()]
+    # df_ipc_adm2 = compute_population_admin(df_ipc_adm2,admin_level,config)
 
 
+
+    #we map names but don't assign admin1's to admin2's if they are missing from the file (e.g. MWI)
     if len(df_ipc[f"ADMIN{admin_level}"].dropna().unique()) == 0:
-        logger.warning(f"No admin {admin_level} regions found in the IPC file")
+        logger.error(f"No admin {admin_level} regions found in the IPC file")
+        return None
+    else:
+        df_ipc = compute_population_admin(df_ipc,admin_level,config)
+        df_ipc_agg = aggregate_adminlevel(df_ipc,admin_level,country,config)
+        #recompute the percentage columns.
+        # Already included in the ipc data but saw that these don't always match the numbers calculated based on the reported populations number, so recompute to be sure they match
+        df_ipc_agg = compute_percentage_columns(df_ipc_agg, config)
 
-    df_ipc_agg = aggregate_adminlevel(df_ipc,admin_level,country,config)
-    print(df_ipc[df_ipc.date=="2020-10-01"][["date","reported_pop_CS","reported_pop_ML1","reported_pop_ML2"]])
-    df_ipc_agg = compute_population_admin(df_ipc_agg,admin_level,config)
-    #recompute the percentage columns.
-    # Already included in the ipc data but these are rounded numbers so want the unrounded numbers based on the raw population numbers
-    df_ipc_agg = compute_percentage_columns(df_ipc_agg, config)
+        # replace values in ipc df
+        # mainly about differently spelled admin regions
+        if "globalipc_adm_mapping" in parameters["foodinsecurity"].keys():
+            globalipc_bound_mapping = parameters["foodinsecurity"]["globalipc_adm_mapping"]
+            df_ipc_agg = df_ipc_agg.replace(globalipc_bound_mapping)
+        #give warning on not matching adm names global ipc and boundaries file
+        #assume admin0 name is correct, cause quickly causes disrepancies due to added strings in Global IPC adm0 name
+        if admin_level!=0:
+            compare_adm_names(df_ipc_agg,country,config,parameters,admin_level)
 
-    #remove columns that haven't been processed
-    ipc_cols = [f"{period}_{i}" for period in config.IPC_PERIOD_NAMES for i in [1, 2, 3, 4, 5]]
-    pop_cols = [f"pop_{period}" for period in config.IPC_PERIOD_NAMES]
-    adm_cols = [f"ADMIN{a}" for a in range(0, int(admin_level) + 1)]
-    df_ipc_agg = df_ipc_agg[["date"] + adm_cols + ipc_cols + pop_cols]
+        #aggregation from adm2 to adm0/1 doesn't always equal the numbers reported directly on adm0/1
+        #raise a warning if this occurs
+        #purely to be aware of the data quality, but can still continue to use the data based on aggregation from adm2
+        test_mismatch_adminlevels(df_ipc_agg,df_ipc,admin_level,country,config)
 
-    # replace values in ipc df
-    # mainly about differently spelled admin regions
-    if "globalipc_adm_mapping" in parameters["foodinsecurity"].keys():
-        globalipc_bound_mapping = parameters["foodinsecurity"]["globalipc_adm_mapping"]
-        df_ipc_agg = df_ipc_agg.replace(globalipc_bound_mapping)
-    #give warning on not matching adm names global ipc and boundaries file
-    compare_adm_names(df_ipc_agg,country,config,parameters,admin_level)
+        #remove columns that haven't been processed
+        ipc_cols = [f"{period}_{i}" for period in config.IPC_PERIOD_NAMES for i in [1, 2, 3, 4, 5]]
+        pop_cols = [f"pop_{period}" for period in config.IPC_PERIOD_NAMES]
+        adm_cols = [f"ADMIN{a}" for a in range(0, int(admin_level) + 1)]
+        df_ipc_agg = df_ipc_agg[["date"] + adm_cols + ipc_cols + pop_cols]
 
-    # TODO: idea to also add total population per admin region, now only have population per admin that was included in the IPC analysis
-    #  Would have to use WorldPop data for that, see process_fewsnet_worldpop.py
+        # TODO: idea to also add total population per admin region, now only have population per admin that was included in the IPC analysis
+        #  Would have to use WorldPop data for that, see process_fewsnet_worldpop.py
 
-    return df_ipc_agg
+        return df_ipc_agg
 
 #TODO: not sure if this function is useful or integrate it with process_globalipc
 def retrieve_globalipc(country, admin_level, suffix="", download=False, config=None):
@@ -218,7 +288,8 @@ def retrieve_globalipc(country, admin_level, suffix="", download=False, config=N
 
     if os.path.exists(os.path.join(globalipc_dir,config.GLOBALIPC_FILENAME_RAW.format(country=country))):
         df_ipc = process_globalipc(country, int(admin_level), config, parameters, globalipc_dir)
-        df_ipc.to_csv(os.path.join(output_dir,config.GLOBALIPC_FILENAME_PROCESSED.format(country=country, admin_level=admin_level,suffix=suffix)))
+        if df_ipc is not None:
+            df_ipc.to_csv(os.path.join(output_dir,config.GLOBALIPC_FILENAME_PROCESSED.format(country=country, admin_level=admin_level,suffix=suffix)))
     else:
         logger.error(f"File doesn't exist at path {os.path.join(globalipc_dir,config.GLOBALIPC_FILENAME_RAW.format(country=country))}. Download the data first by using the -d args")
 


### PR DESCRIPTION
Change the methodology of Global IPC processing on two aspects:
- recompute the population per district (often admin2) by summing the populations of the 5 IPC phases, instead of using the reported population. Done cause we saw discrepancies between the two for some entries. 
- aggregate to admin1 and admin0 by summing the numbers of the districts. The data also report pre-computed numbers on admin1 and admin0 level but they don't always correspond, so for consistency, we want to sum them ourselves. 

Also, code has been implemented to raise a warning if one of these two issues occur. The code will still be run, but it is good to have an indication of the quality of the data. 