### PR TITLE
Bugfix: Updated GloFAS API to round to .x5

### DIFF
--- a/analyses/npl/10_glofas_coord_check.md
+++ b/analyses/npl/10_glofas_coord_check.md
@@ -1,0 +1,87 @@
+Check that the positions of the GloFAS reporting points make sense on the raster
+
+```python
+from pathlib import Path
+import os
+import sys
+import glob
+
+import pandas as pd
+import xarray as xr
+import numpy as np
+import matplotlib.pyplot as plt
+import matplotlib as mpl
+```
+
+```python
+DATA_DIR = Path(os.environ["AA_DATA_DIR"])
+PUBLIC_DIR = DATA_DIR / 'public'
+PRIVATE_DIR = DATA_DIR / 'private'
+
+GLOFAS_NEW_STATIONS = PRIVATE_DIR / 'exploration/glb/glofas/Qgis_World_outlet_202104_20210421.csv'
+NEPAL_RAW_DATA_DIR = PUBLIC_DIR / 'raw/npl/glofas/version_3/cems-glofas-historical/'
+STATIONS_YML = '../../src/nepal/config.yml'
+
+STATIONS = [
+    'Chatara', 'Simle', 'Majhitar', 'Kampughat', 'Rai_goan',
+    'Chisapani', 'Asaraghat', 'Dipayal', 'Samajhighat', 'Kusum', 'Chepang',
+]
+
+path_mod = f"{Path(os.path.dirname(os.path.realpath(''))).parents[0]}/"
+sys.path.append(path_mod)
+from src.utils_general.utils import parse_yaml
+
+mpl.rcParams['figure.dpi'] = 200
+```
+
+```python
+df_stations = pd.DataFrame(index=STATIONS, columns=['v2', 'v3', 'ervin'])
+df_stations_ervin = pd.read_csv(GLOFAS_NEW_STATIONS)
+stations_dict = parse_yaml(STATIONS_YML)['glofas']['stations']
+```
+
+```python
+for station in STATIONS:
+    # Get v2 and v3 stations
+    df_stations.loc[station, 'v2'] = (stations_dict[station]['lon'], stations_dict[station]['lat'])
+    df_stations.loc[station, 'v3'] = (stations_dict[station + '_v3']['lon'], stations_dict[station + '_v3']['lat'])
+    # Get lon lat from Ervin's list
+    station_ervin = station
+    if station_ervin == 'Rai_goan':
+        station_ervin = 'Rai Goan'
+    row_ervin = df_stations_ervin[df_stations_ervin['StationName'] == station_ervin].iloc[-1]
+    df_stations.loc[station, 'ervin'] = (row_ervin['LisfloodX'], row_ervin['LisfloodY'])
+```
+
+## Read in raw GloFAS data
+
+```python
+# This takes a minute
+da = xr.open_mfdataset([str(filename) for filename in NEPAL_RAW_DATA_DIR.glob('*.grib')],
+                                        engine='cfgrib')['dis24']
+```
+
+```python
+# As a start, take the average as a proxy for local 'best'
+rd = np.log10(da.mean(axis=0))
+z = rd.values
+```
+
+```python
+res = 0.05
+extent=[da.longitude[0]-res, da.longitude[-1]+res, da.latitude[-1]-res, da.latitude[0]+res]
+
+fig, ax = plt.subplots(figsize=(25, 10))
+im = ax.imshow(z, extent=extent, cmap='Greys_r', vmin=0)
+cb = plt.colorbar(im)
+cb.set_label('Log mean river discharge from 1979 to present')
+ax.grid()
+
+for station, row in df_stations.iterrows():
+    x, y = row['v3']
+    ax.plot(x, y, 'o', label=station)
+ax.legend()
+ax.set_xlabel('lon')
+ax.set_ylabel('lat')
+
+```

--- a/src/indicators/flooding/glofas/area.py
+++ b/src/indicators/flooding/glofas/area.py
@@ -1,20 +1,53 @@
 from collections import namedtuple
-from typing import Dict
+from typing import Dict, List
 
 from shapely.geometry import Polygon
+import numpy as np
 
+GLOFAS_ROUND_VAL = 0.1
+GLOFAS_OFFSET_VAL = 0.05
 Station = namedtuple("Station", "lon lat")
 
 
 class Area:
-    def __init__(self, north, south, east, west):
+    def __init__(self, north: float, south: float, east: float, west: float):
         self.north = north
         self.south = south
         self.east = east
         self.west = west
 
-    def list_for_api(self):
-        return [self.north, self.west, self.south, self.east]
+    def list_for_api(self, do_not_round: bool = False) -> List[float]:
+        """
+        List the coordinates in the order that they're needed for the API
+        :param do_not_round: Don't round to the format x.y5, which is required for the API.
+        Only left as a parameter for now to be able to replicate older datasets
+        -- should generally not be toggled
+        :return: List of coordinates in the correct order for the API (north, west, south, east)
+        """
+        if do_not_round:
+            return [self.north, self.west, self.south, self.east]
+        # Round North and East up, South and West down (to maximize area)
+        north = self._round_coord_glofas(coord=self.north, direction="up")
+        east = self._round_coord_glofas(coord=self.east, direction="up")
+        south = self._round_coord_glofas(coord=self.south, direction="down")
+        west = self._round_coord_glofas(coord=self.west, direction="down")
+        return [north, west, south, east]
+
+    @staticmethod
+    def _round_coord_glofas(coord: float, direction: str) -> float:
+        """
+        Rounding for GloFAS in the CDS API, to the format x.y5
+        :param coord: The coordinate to round
+        :param direction: Round up or down
+        :return: Coordinate rounded to x.y5
+        """
+        if direction == "up":
+            function = np.ceil
+            offset_factor = 1
+        elif direction == "down":
+            function = np.floor
+            offset_factor = -1
+        return function(coord / GLOFAS_ROUND_VAL) * GLOFAS_ROUND_VAL + offset_factor * GLOFAS_OFFSET_VAL
 
 
 class AreaFromStations(Area):

--- a/src/nepal/get_glofas_data.py
+++ b/src/nepal/get_glofas_data.py
@@ -29,15 +29,16 @@ SHAPEFILE = (
     / "npl_admbnda_nd_20201117_shp.zip!npl_admbnda_adm0_nd_20201117.shp"
 )
 VERSION = 3
+USE_INCORRECT_COORDS = False
 
 logging.basicConfig(level=logging.INFO, force=True)
 logger = logging.getLogger(__name__)
 
 
-def main(download=False, process=True):
+def main(download=True, process=True):
 
-    glofas_reanalysis = glofas.GlofasReanalysis()
-    glofas_reforecast = glofas.GlofasReforecast()
+    glofas_reanalysis = glofas.GlofasReanalysis(use_incorrect_area_coords=USE_INCORRECT_COORDS)
+    glofas_reforecast = glofas.GlofasReforecast(use_incorrect_area_coords=USE_INCORRECT_COORDS)
 
     if download:
         df_admin_boundaries = gpd.read_file(f"zip://{SHAPEFILE}")

--- a/tests/test_glofas.py
+++ b/tests/test_glofas.py
@@ -33,7 +33,7 @@ class TestDownload(unittest.TestCase):
         self.area = Area(north=1, south=-2, east=3, west=-4)
         self.year = 2000
         self.leadtime = 10
-        self.expected_area = [1, -4, -2, 3]
+        self.expected_area = [1.05, -4.05, -2.05, 3.05]
         self.expected_months = [str(x + 1).zfill(2) for x in range(12)]
         self.expected_days = [str(x + 1).zfill(2) for x in range(31)]
         self.expected_leadtime = 240

--- a/tests/test_glofas_area.py
+++ b/tests/test_glofas_area.py
@@ -21,7 +21,7 @@ def test_get_area_from_stations():
 
 def test_get_list_for_api():
     area = AreaFromStations(FAKE_STATIONS, buffer=0)
-    assert area.list_for_api() == [1, -4, -2, 3]
+    assert area.list_for_api() == [1.05, -4.05, -2.05, 3.05]
 
 
 def test_get_area_from_shape():


### PR DESCRIPTION
For downloading GloFAS data from the CDS API, you need to pass the area rounded as .x5. This PR corrects the issue, but also allows a legacy parameter for accessing the incorrect data for now. Should probably be removed at a later date. 

@hannahker what do you think about the legacy directory structure? Right now I just tack "incorrect_coords" on to the version directory. Do you think it's better to put a separate directory in the version directory instead or something? What about for the processed data? (I just changed the filenames there).

Note that you will need to change the directory & filenames by hand. I've done so for Nepal, will take care of Bangladesh at a later date. 