### PR TITLE
GloFAS reforecast by year

### DIFF
--- a/src/indicators/flooding/glofas/glofas.py
+++ b/src/indicators/flooding/glofas/glofas.py
@@ -21,6 +21,7 @@ PROCESSED_DATA_DIR = "processed"
 GLOFAS_DIR = "glofas"
 DEFAULT_VERSION = 3
 HYDROLOGICAL_MODELS = {2: "htessel_lisflood", 3: "lisflood"}
+RIVER_DISCHARGE_VAR = "dis24"
 
 logger = logging.getLogger(__name__)
 
@@ -189,7 +190,7 @@ class Glofas:
                 if data_type == "cf":
                     ds = expand_dims(
                         ds=ds,
-                        dataset_name="dis24",
+                        dataset_name=RIVER_DISCHARGE_VAR,
                         coord_names=["number", "time", "step", "latitude", "longitude"],
                         expansion_dim=0,
                     )
@@ -318,103 +319,13 @@ class GlofasReanalysis(Glofas):
         )
 
 
-class GlofasForecast(Glofas):
-    def __init__(self, **kwargs):
-        super().__init__(
-            year_min={2: 2019, 3: 2020},
-            year_max=2020,
-            cds_name="cems-glofas-forecast",
-            dataset=["control_forecast", "ensemble_perturbed_forecasts"],
-            system_version_minor={2: 1, 3: 1},
-            dataset_variable_name="product_type",
-            **kwargs,
-        )
+class GlofasForecastBase(Glofas):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
-    def download(
+    def _download(
         self,
-        country_iso3: str,
-        area: Area,
-        leadtimes: List[int],
-        version: int = DEFAULT_VERSION,
-        split_by_leadtimes: bool = False,
-        year_min: int = None,
-        year_max: int = None,
-    ):
-        year_min = self.year_min[version] if year_min is None else year_min
-        year_max = self.year_max if year_max is None else year_max
-        logger.info(
-            f"Downloading GloFAS forecast v{version} for years {year_min} - {year_max} and lead time {leadtimes}"
-        )
-        for year in range(year_min, year_max + 1):
-            logger.info(f"...{year}")
-            leadtime_range = leadtimes if split_by_leadtimes else [leadtimes]
-            for leadtime in leadtime_range:
-                super()._download(
-                    country_iso3=country_iso3,
-                    area=area,
-                    year=year,
-                    leadtime=leadtime,
-                    version=version,
-                )
-
-    def process(
-        self,
-        country_iso3: str,
-        stations: Dict[str, Station],
-        leadtimes: List[int],
-        version: int = DEFAULT_VERSION,
-        split_by_leadtimes: bool = False,
-        year_min: int = None,
-        year_max: int = None,
-    ):
-        year_min = self.year_min[version] if year_min is None else year_min
-        year_max = self.year_max if year_max is None else year_max
-        logger.info(f"Processing GloFAS Forecast v{version} for years {year_min} - {year_max} and lead time {leadtimes}")
-        leadtime_range = leadtimes if split_by_leadtimes else [leadtimes]
-        for leadtime in leadtime_range:
-            logger.info(f"For lead time {leadtime}")
-            # Get list of files to open
-            filepath_list = [
-                self._get_raw_filepath(
-                    country_iso3=country_iso3,
-                    version=version,
-                    year=year,
-                    leadtime=leadtime,
-                )
-                for year in range(year_min, year_max + 1)
-            ]
-            # Read in both the control and ensemble perturbed forecast and combine
-            logger.info(f"Reading in {len(filepath_list)} files")
-            ds = self._read_in_ensemble_and_perturbed_datasets(filepath_list)
-            # Create a new dataset with just the station pixels
-            logger.info("Looping through stations, this takes some time")
-            ds_new = _get_station_dataset(
-                stations=stations, ds=ds, coord_names=["number", "time", "step"]
-            )
-            # Write out the new dataset to a file
-            self._write_to_processed_file(
-                country_iso3=country_iso3,
-                ds=ds_new,
-                leadtime=leadtime,
-                version=version,
-            )
-
-
-class GlofasReforecast(Glofas):
-    def __init__(self, **kwargs):
-        super().__init__(
-            year_min=1999,
-            year_max=2018,
-            cds_name="cems-glofas-reforecast",
-            dataset=["control_reforecast", "ensemble_perturbed_reforecasts"],
-            dataset_variable_name="product_type",
-            system_version_minor={2: 2, 3: 1},
-            date_variable_prefix="h",
-            **kwargs,
-        )
-
-    def download(
-        self,
+        is_reforecast: bool,
         country_iso3: str,
         area: Area,
         leadtimes: List[int],
@@ -424,10 +335,11 @@ class GlofasReforecast(Glofas):
         year_min: int = None,
         year_max: int = None,
     ):
-        year_min = self.year_min if year_min is None else year_min
+        forecast_type = "reforecast" if is_reforecast else "forecast"
+        year_min = self.year_min[version] if year_min is None else year_min
         year_max = self.year_max if year_max is None else year_max
         logger.info(
-            f"Downloading GloFAS reforecast v{version} for years {year_min} - {year_max} and lead time {leadtimes}"
+            f"Downloading GloFAS {forecast_type} v{version} for years {year_min} - {year_max} and lead time {leadtimes}"
         )
         for year in range(year_min, year_max + 1):
             logger.info(f"...{year}")
@@ -444,8 +356,9 @@ class GlofasReforecast(Glofas):
                         leadtime=leadtime,
                     )
 
-    def process(
+    def _process(
         self,
+        is_reforecast: bool,
         country_iso3: str,
         stations: Dict[str, Station],
         leadtimes: List[int],
@@ -455,9 +368,12 @@ class GlofasReforecast(Glofas):
         year_min: int = None,
         year_max: int = None,
     ):
-        year_min = self.year_min if year_min is None else year_min
+        forecast_type = "reforecast" if is_reforecast else "forecast"
+        year_min = self.year_min[version] if year_min is None else year_min
         year_max = self.year_max if year_max is None else year_max
-        logger.info(f"Processing GloFAS Reforecast v{version} for years {year_min} - {year_max} and lead time {leadtimes}")
+        logger.info(
+            f"Processing GloFAS {forecast_type} v{version} for years {year_min} - {year_max} and lead time {leadtimes}"
+        )
         month_range = range(1, 13) if split_by_month else [None]
         leadtime_range = leadtimes if split_by_leadtimes else [leadtimes]
         for leadtime in leadtime_range:
@@ -481,8 +397,13 @@ class GlofasReforecast(Glofas):
             )
             # Create a new dataset with just the station pixels
             logger.info("Looping through stations, this takes some time")
+            coord_names = ["number", "time"]
+            if not split_by_leadtimes:
+                coord_names += ["step"]
             ds_new = _get_station_dataset(
-                stations=stations, ds=ds, coord_names=["number", "time", "step"]
+                stations=stations,
+                ds=ds,
+                coord_names=coord_names,
             )
             # Write out the new dataset to a file
             self._write_to_processed_file(
@@ -491,6 +412,45 @@ class GlofasReforecast(Glofas):
                 ds=ds_new,
                 leadtime=leadtime,
             )
+
+
+class GlofasForecast(GlofasForecastBase):
+    def __init__(self, **kwargs):
+        super().__init__(
+            year_min={2: 2019, 3: 2020},
+            year_max=2020,
+            cds_name="cems-glofas-forecast",
+            dataset=["control_forecast", "ensemble_perturbed_forecasts"],
+            system_version_minor={2: 1, 3: 1},
+            dataset_variable_name="product_type",
+            **kwargs,
+        )
+
+    def download(self, *args, **kwargs):
+        super()._download(is_reforecast=False, *args, **kwargs)
+
+    def process(self, *args, **kwargs):
+        super()._process(is_reforecast=False, *args, **kwargs)
+
+
+class GlofasReforecast(GlofasForecastBase):
+    def __init__(self, **kwargs):
+        super().__init__(
+            year_min={2: 1999, 3: 1999},
+            year_max=2018,
+            cds_name="cems-glofas-reforecast",
+            dataset=["control_reforecast", "ensemble_perturbed_reforecasts"],
+            dataset_variable_name="product_type",
+            system_version_minor={2: 2, 3: 1},
+            date_variable_prefix="h",
+            **kwargs,
+        )
+
+    def download(self, *args, **kwargs):
+        super()._download(is_reforecast=True, *args, **kwargs)
+
+    def process(self, *args, **kwargs):
+        super()._process(is_reforecast=True, *args, **kwargs)
 
 
 def expand_dims(
@@ -556,10 +516,9 @@ def _get_station_dataset(
         data_vars={
             station_name: (
                 coord_names,
-                ds.isel(
-                    longitude=np.abs(ds.longitude - station.lon).argmin(),
-                    latitude=np.abs(ds.latitude - station.lat).argmin(),
-                )["dis24"],
+                ds.sel(longitude=station.lon, latitude=station.lat, method="nearest")[
+                    RIVER_DISCHARGE_VAR
+                ],
             )
             for station_name, station in stations.items()
         },

--- a/src/indicators/flooding/glofas/glofas.py
+++ b/src/indicators/flooding/glofas/glofas.py
@@ -36,7 +36,7 @@ class Glofas:
         dataset_variable_name: str,
         system_version_minor: Dict[int, int],
         date_variable_prefix: str = "",
-        use_incorrect_area_coords=False,
+        use_incorrect_area_coords: bool = False,
     ):
         """
         Create an instance of a GloFAS object, from which you can download and process raw data, and

--- a/src/indicators/flooding/glofas/glofas.py
+++ b/src/indicators/flooding/glofas/glofas.py
@@ -342,12 +342,12 @@ class GlofasForecast(Glofas):
     ):
         year_min = self.year_min[version] if year_min is None else year_min
         year_max = self.year_max if year_max is None else year_max
-        leadtime_range = leadtimes if split_by_leadtimes else [leadtimes]
         logger.info(
             f"Downloading GloFAS forecast v{version} for years {year_min} - {year_max} and lead time {leadtimes}"
         )
         for year in range(year_min, year_max + 1):
             logger.info(f"...{year}")
+            leadtime_range = leadtimes if split_by_leadtimes else [leadtimes]
             for leadtime in leadtime_range:
                 super()._download(
                     country_iso3=country_iso3,
@@ -364,9 +364,13 @@ class GlofasForecast(Glofas):
         leadtimes: List[int],
         version: int = DEFAULT_VERSION,
         split_by_leadtimes: bool = False,
+        year_min: int = None,
+        year_max: int = None,
     ):
+        year_min = self.year_min[version] if year_min is None else year_min
+        year_max = self.year_max if year_max is None else year_max
+        logger.info(f"Processing GloFAS Forecast v{version} for years {year_min} - {year_max} and lead time {leadtimes}")
         leadtime_range = leadtimes if split_by_leadtimes else [leadtimes]
-        logger.info(f"Processing GloFAS Forecast v{version}")
         for leadtime in leadtime_range:
             logger.info(f"For lead time {leadtime}")
             # Get list of files to open
@@ -377,7 +381,7 @@ class GlofasForecast(Glofas):
                     year=year,
                     leadtime=leadtime,
                 )
-                for year in range(self.year_min[version], self.year_max + 1)
+                for year in range(year_min, year_max + 1)
             ]
             # Read in both the control and ensemble perturbed forecast and combine
             logger.info(f"Reading in {len(filepath_list)} files")
@@ -385,7 +389,7 @@ class GlofasForecast(Glofas):
             # Create a new dataset with just the station pixels
             logger.info("Looping through stations, this takes some time")
             ds_new = _get_station_dataset(
-                stations=stations, ds=ds, coord_names=["number", "time"]
+                stations=stations, ds=ds, coord_names=["number", "time", "step"]
             )
             # Write out the new dataset to a file
             self._write_to_processed_file(
@@ -422,14 +426,14 @@ class GlofasReforecast(Glofas):
     ):
         year_min = self.year_min if year_min is None else year_min
         year_max = self.year_max if year_max is None else year_max
-        month_range = range(1, 13) if split_by_month else [None]
-        leadtime_range = leadtimes if split_by_leadtimes else [leadtimes]
         logger.info(
             f"Downloading GloFAS reforecast v{version} for years {year_min} - {year_max} and lead time {leadtimes}"
         )
         for year in range(year_min, year_max + 1):
             logger.info(f"...{year}")
+            month_range = range(1, 13) if split_by_month else [None]
             for month in month_range:
+                leadtime_range = leadtimes if split_by_leadtimes else [leadtimes]
                 for leadtime in leadtime_range:
                     super()._download(
                         country_iso3=country_iso3,
@@ -448,11 +452,14 @@ class GlofasReforecast(Glofas):
         version: int = DEFAULT_VERSION,
         split_by_month: bool = False,
         split_by_leadtimes: bool = False,
+        year_min: int = None,
+        year_max: int = None,
     ):
-
+        year_min = self.year_min if year_min is None else year_min
+        year_max = self.year_max if year_max is None else year_max
+        logger.info(f"Processing GloFAS Reforecast v{version} for years {year_min} - {year_max} and lead time {leadtimes}")
         month_range = range(1, 13) if split_by_month else [None]
         leadtime_range = leadtimes if split_by_leadtimes else [leadtimes]
-        logger.info(f"Processing GloFAS Reforecast v{version}")
         for leadtime in leadtime_range:
             logger.info(f"For lead time {leadtime}")
             # Get list of files to open
@@ -464,7 +471,7 @@ class GlofasReforecast(Glofas):
                     month=month,
                     leadtime=leadtime,
                 )
-                for year in range(self.year_min, self.year_max + 1)
+                for year in range(year_min, year_max + 1)
                 for month in month_range
             ]
             # Read in both the control and ensemble perturbed forecast and combine
@@ -475,7 +482,7 @@ class GlofasReforecast(Glofas):
             # Create a new dataset with just the station pixels
             logger.info("Looping through stations, this takes some time")
             ds_new = _get_station_dataset(
-                stations=stations, ds=ds, coord_names=["number", "time"]
+                stations=stations, ds=ds, coord_names=["number", "time", "step"]
             )
             # Write out the new dataset to a file
             self._write_to_processed_file(

--- a/src/indicators/flooding/glofas/utils.py
+++ b/src/indicators/flooding/glofas/utils.py
@@ -24,20 +24,52 @@ def get_glofas_reanalysis(
     return ds_glofas_reanalysis
 
 
-def get_glofas_forecast(
-    country_iso3: str, leadtimes: List[int], version: int = glofas.DEFAULT_VERSION
-) -> xr.Dataset:
-    glofas_forecast = glofas.GlofasForecast()
-    ds_glofas_forecast_dict = {
-        leadtime: glofas_forecast.read_processed_dataset(
+def _get_glofas_forecast_base(
+    is_reforecast: bool,
+    country_iso3: str,
+    leadtimes: List[int],
+    interp: bool = False,
+    version: int = glofas.DEFAULT_VERSION,
+    split_by_leadtimes: bool = False
+):
+    if is_reforecast:
+        glofas_forecast = glofas.GlofasReforecast()
+    else:
+        glofas_forecast = glofas.GlofasForecast()
+    if split_by_leadtimes:
+        ds_glofas_forecast_dict = {
+            leadtime: glofas_forecast.read_processed_dataset(
+                country_iso3=country_iso3,
+                version=version,
+                leadtime=leadtime,
+            )
+            for leadtime in leadtimes
+        }
+    else:
+        # Split up the dataset into different leadtimes, because then it's easier to do the shifts
+        ds_glofas_forecast = glofas_forecast.read_processed_dataset(
             country_iso3=country_iso3,
-            leadtime=leadtime,
-            version=version,
+            version=version
         )
-        for leadtime in leadtimes
-    }
+        ds_glofas_forecast_dict = {
+            leadtime: ds_glofas_forecast.sel(step=np.timedelta64(leadtime, 'D'))
+            for leadtime in leadtimes
+        }
+    if interp:
+        ds_glofas_forecast_dict = _interp_dates(ds_glofas_forecast_dict)
     ds_glofas_forecast_dict = _shift_dates(ds_glofas_forecast_dict)
     return _convert_dict_to_ds(ds_glofas_forecast_dict)
+
+
+def get_glofas_forecast(
+    country_iso3: str, leadtimes: List[int], version: int = glofas.DEFAULT_VERSION, split_by_leadtimes=False
+) -> xr.Dataset:
+    return _get_glofas_forecast_base(is_reforecast=False,
+                                     country_iso3=country_iso3,
+                                     leadtimes=leadtimes,
+                                     version=version,
+                                     split_by_leadtimes=split_by_leadtimes
+                                     )
 
 
 def get_glofas_reforecast(
@@ -45,20 +77,15 @@ def get_glofas_reforecast(
     leadtimes: List[int],
     interp: bool = True,
     version: int = glofas.DEFAULT_VERSION,
+    split_by_leadtimes: bool = False
 ) -> xr.Dataset:
-    glofas_reforecast = glofas.GlofasReforecast()
-    ds_glofas_reforecast_dict = {
-        leadtime: glofas_reforecast.read_processed_dataset(
-            country_iso3=country_iso3,
-            version=version,
-            leadtime=leadtime,
-        )
-        for leadtime in leadtimes
-    }
-    if interp:
-        ds_glofas_reforecast_dict = _interp_dates(ds_glofas_reforecast_dict)
-    ds_glofas_reforecast_dict = _shift_dates(ds_glofas_reforecast_dict)
-    return _convert_dict_to_ds(ds_glofas_reforecast_dict)
+    return _get_glofas_forecast_base(is_reforecast=True,
+                                     country_iso3=country_iso3,
+                                     leadtimes=leadtimes,
+                                     interp=interp,
+                                     version=version,
+                                     split_by_leadtimes=split_by_leadtimes
+                                     )
 
 
 def _shift_dates(ds_dict) -> Dict[int, xr.Dataset]:

--- a/src/indicators/flooding/glofas/utils.py
+++ b/src/indicators/flooding/glofas/utils.py
@@ -8,7 +8,10 @@ from scipy.stats import rankdata
 import xskillscore as xs
 
 from src.indicators.flooding.glofas import glofas
-from src.utils_general.statistics import get_return_period_function_analytical, get_return_period_function_empirical
+from src.utils_general.statistics import (
+    get_return_period_function_analytical,
+    get_return_period_function_empirical,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -30,7 +33,7 @@ def _get_glofas_forecast_base(
     leadtimes: List[int],
     interp: bool = False,
     version: int = glofas.DEFAULT_VERSION,
-    split_by_leadtimes: bool = False
+    split_by_leadtimes: bool = False,
 ):
     if is_reforecast:
         glofas_forecast = glofas.GlofasReforecast()
@@ -48,11 +51,10 @@ def _get_glofas_forecast_base(
     else:
         # Split up the dataset into different leadtimes, because then it's easier to do the shifts
         ds_glofas_forecast = glofas_forecast.read_processed_dataset(
-            country_iso3=country_iso3,
-            version=version
+            country_iso3=country_iso3, version=version
         )
         ds_glofas_forecast_dict = {
-            leadtime: ds_glofas_forecast.sel(step=np.timedelta64(leadtime, 'D'))
+            leadtime: ds_glofas_forecast.sel(step=np.timedelta64(leadtime, "D"))
             for leadtime in leadtimes
         }
     if interp:
@@ -62,14 +64,18 @@ def _get_glofas_forecast_base(
 
 
 def get_glofas_forecast(
-    country_iso3: str, leadtimes: List[int], version: int = glofas.DEFAULT_VERSION, split_by_leadtimes=False
+    country_iso3: str,
+    leadtimes: List[int],
+    version: int = glofas.DEFAULT_VERSION,
+    split_by_leadtimes=False,
 ) -> xr.Dataset:
-    return _get_glofas_forecast_base(is_reforecast=False,
-                                     country_iso3=country_iso3,
-                                     leadtimes=leadtimes,
-                                     version=version,
-                                     split_by_leadtimes=split_by_leadtimes
-                                     )
+    return _get_glofas_forecast_base(
+        is_reforecast=False,
+        country_iso3=country_iso3,
+        leadtimes=leadtimes,
+        version=version,
+        split_by_leadtimes=split_by_leadtimes,
+    )
 
 
 def get_glofas_reforecast(
@@ -77,15 +83,16 @@ def get_glofas_reforecast(
     leadtimes: List[int],
     interp: bool = True,
     version: int = glofas.DEFAULT_VERSION,
-    split_by_leadtimes: bool = False
+    split_by_leadtimes: bool = False,
 ) -> xr.Dataset:
-    return _get_glofas_forecast_base(is_reforecast=True,
-                                     country_iso3=country_iso3,
-                                     leadtimes=leadtimes,
-                                     interp=interp,
-                                     version=version,
-                                     split_by_leadtimes=split_by_leadtimes
-                                     )
+    return _get_glofas_forecast_base(
+        is_reforecast=True,
+        country_iso3=country_iso3,
+        leadtimes=leadtimes,
+        interp=interp,
+        version=version,
+        split_by_leadtimes=split_by_leadtimes,
+    )
 
 
 def _shift_dates(ds_dict) -> Dict[int, xr.Dataset]:
@@ -175,11 +182,15 @@ def get_return_periods(
         df_rp = _get_return_period_df(ds_reanalysis=ds_reanalysis, station=station)
         if method == "analytical":
             f_rp = get_return_period_function_analytical(
-                df_rp=df_rp, rp_var="discharge", show_plots=show_plots, plot_title=station
+                df_rp=df_rp,
+                rp_var="discharge",
+                show_plots=show_plots,
+                plot_title=station,
             )
         elif method == "empirical":
             f_rp = get_return_period_function_empirical(
-                df_rp=df_rp, rp_var="discharge",
+                df_rp=df_rp,
+                rp_var="discharge",
             )
         else:
             logger.error(f"{method} is not a valid keyword for method")

--- a/src/nepal/get_glofas_data.py
+++ b/src/nepal/get_glofas_data.py
@@ -16,7 +16,8 @@ from src.utils_general.utils import parse_yaml
 
 # Stations from here: https://drive.google.com/file/d/1oNaavhzD2u5nZEGcEjmRn944rsQfBzfz/view
 COUNTRY_ISO3 = "npl"
-LEADTIMES = [x + 1 for x in range(20)]
+LEADTIMES = [x + 1 for x in range(10)]  # for v3 correct coords only went to lead time 10 days
+# LEADTIMES = [x + 1 for x in range(20)]
 
 STATIONS = parse_yaml('src/nepal/config.yml')['glofas']['stations']
 

--- a/tests/test_glofas.py
+++ b/tests/test_glofas.py
@@ -32,11 +32,11 @@ class TestDownload(unittest.TestCase):
         self.country_iso3 = "abc"
         self.area = Area(north=1, south=-2, east=3, west=-4)
         self.year = 2000
-        self.leadtime = 10
+        self.leadtime = [10, 20]
         self.expected_area = [1.05, -4.05, -2.05, 3.05]
         self.expected_months = [str(x + 1).zfill(2) for x in range(12)]
         self.expected_days = [str(x + 1).zfill(2) for x in range(31)]
-        self.expected_leadtime = 240
+        self.expected_leadtime = ["240", "480"]
 
     def test_reanalysis_download(self, fake_mkdir, fake_retrieve):
         glofas_reanalysis = glofas.GlofasReanalysis()
@@ -71,7 +71,7 @@ class TestDownload(unittest.TestCase):
         glofas_forecast.download(
             country_iso3=self.country_iso3,
             area=self.area,
-            leadtimes=[self.leadtime],
+            leadtimes=self.leadtime,
             year_min=self.year,
             year_max=self.year,
         )
@@ -87,25 +87,17 @@ class TestDownload(unittest.TestCase):
                 "area": self.expected_area,
                 "system_version": "version_3_1",
                 "hydrological_model": "lisflood",
-                "leadtime_hour": f"{self.expected_leadtime}",
+                "leadtime_hour": self.expected_leadtime,
             },
             "target": Path(
                 f"/tmp/public/raw/{self.country_iso3}/glofas/version_3/cems-glofas-forecast"
-                f"/{self.country_iso3}_cems-glofas-forecast_v3_2000_lt10d.grib"
+                f"/{self.country_iso3}_cems-glofas-forecast_v3_2000.grib"
             ),
         }
         fake_retrieve.assert_called_with(**expected_args)
 
-    def test_reforecast_download(self, fake_mkdir, fake_retrieve):
-        glofas_reforecast = glofas.GlofasReforecast()
-        glofas_reforecast.download(
-            country_iso3=self.country_iso3,
-            area=self.area,
-            leadtimes=[self.leadtime],
-            year_min=self.year,
-            year_max=self.year,
-        )
-        expected_args = {
+    def get_reforecast_expected_args(self):
+        return {
             "name": "cems-glofas-reforecast",
             "request": {
                 "variable": "river_discharge_in_the_last_24_hours",
@@ -120,11 +112,39 @@ class TestDownload(unittest.TestCase):
                 "area": self.expected_area,
                 "system_version": "version_3_1",
                 "hydrological_model": "lisflood",
-                "leadtime_hour": f"{self.expected_leadtime}",
+                "leadtime_hour": self.expected_leadtime,
             },
             "target": Path(
                 f"/tmp/public/raw/{self.country_iso3}/glofas/version_3/cems-glofas-reforecast"
-                f"/{self.country_iso3}_cems-glofas-reforecast_v3_2000_lt10d.grib"
+                f"/{self.country_iso3}_cems-glofas-reforecast_v3_2000.grib"
             ),
         }
+
+    def test_reforecast_download(self, fake_mkdir, fake_retrieve):
+        glofas_reforecast = glofas.GlofasReforecast()
+        glofas_reforecast.download(
+            country_iso3=self.country_iso3,
+            area=self.area,
+            leadtimes=self.leadtime,
+            year_min=self.year,
+            year_max=self.year,
+        )
+        fake_retrieve.assert_called_with(**self.get_reforecast_expected_args())
+
+    def test_reforecast_download_split_by_leadtime(self, fake_mkdir, fake_retrieve):
+        glofas_reforecast = glofas.GlofasReforecast()
+        glofas_reforecast.download(
+            country_iso3=self.country_iso3,
+            area=self.area,
+            leadtimes=self.leadtime[:1],
+            year_min=self.year,
+            year_max=self.year,
+            split_by_leadtimes=True,
+        )
+        expected_args = self.get_reforecast_expected_args()
+        expected_args["request"]["leadtime_hour"] = self.expected_leadtime[:1]
+        expected_args["target"] = Path(
+            f"/tmp/public/raw/{self.country_iso3}/glofas/version_3/cems-glofas-reforecast"
+            f"/{self.country_iso3}_cems-glofas-reforecast_v3_2000_lt10d.grib"
+        )
         fake_retrieve.assert_called_with(**expected_args)


### PR DESCRIPTION
Update GloFAS forecast / reforecast to not be split by leadtime but by year only. I wanted to do this for awhile but now it's necessary due to the data the Chris gave us where the leadtimes are combined. 