### PR TITLE
Switched to pytest

### DIFF
--- a/tests/test_glofas.py
+++ b/tests/test_glofas.py
@@ -1,4 +1,3 @@
-import unittest
 from unittest import mock
 from pathlib import Path
 
@@ -30,8 +29,8 @@ def test_expand_dims():
 @mock.patch("src.indicators.flooding.glofas.glofas.cdsapi.Client.retrieve")
 @mock.patch("src.indicators.flooding.glofas.glofas.Path.mkdir")
 @mock.patch.object(glofas, "DATA_DIR", Path("/tmp"))
-class TestDownload(unittest.TestCase):
-    def setUp(self):
+class TestDownload:
+    def setup_class(self):
         self.country_iso3 = "abc"
         self.area = Area(north=1, south=-2, east=3, west=-4)
         self.year = 2000


### PR DESCRIPTION
Quick switch to Pytest `setup_class` method instead of using the `unittest.testcase` class.

However, @mcarans I was wondering if there could be an even more pytest-y way to do this using fixtures. I use the class setup to collect a few variables that are used throughout several of the tests. I don't have much experience with using fixtures so I thought that you might have an idea for this specific case. 