### PR TITLE
Add option to get ECMWF API seasonal precip

### DIFF
--- a/analyses/mwi/dryspells_trigger/exploration/ecmwf_low_high_res_compare.md
+++ b/analyses/mwi/dryspells_trigger/exploration/ecmwf_low_high_res_compare.md
@@ -1,0 +1,53 @@
+This notebook is for checking that the ECMWF data downloaded
+from their API is equivalent and has been processed in a similar
+manner to the data from CDS that we've been using so far.
+
+```python
+from pathlib import Path
+import os
+import sys
+from datetime import datetime
+
+path_mod = f"{Path(os.path.dirname(os.path.abspath(''))).parents[2]}/"
+sys.path.append(path_mod)
+from src.indicators.drought.ecmwf_seasonal import processing
+```
+
+```python
+ISO3 = 'mwi'
+VAR = 'precip'
+```
+
+```python
+# Read in the two dataframes: One from CDS and the other from ECMWF API
+da_cds = processing.get_ecmwf_forecast(ISO3)[VAR]
+da_ecmwf =  processing.get_ecmwf_forecast(ISO3, source_cds=False)[VAR]
+```
+
+```python
+# Need to flatten the data arrays to compare parameters across x-y coordinates.
+# Can play around with these to view different times, ensemble member numbers,
+# and forecast steps. 
+time = datetime(1999, 1, 1)
+number = 3
+step = 2
+
+data_cds = da_cds.sel(time=time, number=number, step=step)
+data_ecmwf = da_ecmwf.sel(time=time, number=number, step=step)
+```
+
+```python
+# CDS data has 1 deg resolution
+data_cds.plot()
+```
+
+```python
+data_ecmwf.latitude
+```
+
+```python
+# ECMWF has 0.4 deg resolution, but coarsen only lets you combine
+# integer number of pixels so can't reproduce the CDS resolution exactly.
+# But it does look pretty close.
+data_ecmwf.coarsen(longitude=2, latitude=2).mean().plot()
+```

--- a/src/indicators/drought/ecmwf_seasonal/processing.py
+++ b/src/indicators/drought/ecmwf_seasonal/processing.py
@@ -90,6 +90,7 @@ def get_stats_filepath(
     config: Config,
     date: datetime,
     adm_level: int,
+    source_cds: bool,
     use_unrounded_area_coords: bool,
     resolution: float = None,
     all_touched: bool = False,
@@ -102,6 +103,7 @@ def get_stats_filepath(
     :param date: the date of interest
     If None, data is in original resolution
     :param adm_level: the admin level the data is aggregated to
+    :param source_cds: whether the data comes from CDS, or the ECMWF API
     :param use_unrounded_area_coords: Generally meant to be False,
         needed for backward compatibility with some historical data.
         If True, no rounding to the coordinates will be done which results in
@@ -126,12 +128,32 @@ def get_stats_filepath(
         filename += "_all-touched"
     filename += f"_{date.year}_{date.month}_adm{adm_level}_stats.csv"
 
-    country_data_processed_dir = (
-        Path(config.DATA_DIR) / config.PUBLIC_DIR / config.PROCESSED_DIR / iso3
-    )
-    ecmwf_processed_dir = country_data_processed_dir / config.ECMWF_DIR
+    if source_cds:
+        country_data_processed_dir = (
+            Path(config.DATA_DIR)
+            / config.PUBLIC_DIR
+            / config.PROCESSED_DIR
+            / iso3
+        )
+        stats_dir = (
+            country_data_processed_dir
+            / config.ECMWF_DIR
+            / "seasonal-monthly-single-levels"
+        )
+    else:
+        country_data_processed_dir = (
+            Path(config.DATA_DIR)
+            / config.PRIVATE_DIR
+            / config.PROCESSED_DIR
+            / iso3
+        )
+        stats_dir = (
+            country_data_processed_dir
+            / config.ECMWF_DIR
+            / "seasonal-monthly-individual-members"
+            / "prate"
+        )
 
-    stats_dir = ecmwf_processed_dir / "seasonal-monthly-single-levels"
     if use_unrounded_area_coords:
         stats_dir = stats_dir / "unrounded-coords"
 
@@ -203,6 +225,7 @@ def compute_stats_per_admin(
             config=config,
             date=date_dt,
             adm_level=adm_level,
+            source_cds=source_cds,
             use_unrounded_area_coords=use_unrounded_area_coords,
             resolution=resolution,
             all_touched=all_touched,

--- a/src/mwi/get_ecmwf_seasonal_data.py
+++ b/src/mwi/get_ecmwf_seasonal_data.py
@@ -38,6 +38,7 @@ ADM0_BOUND_PATH = os.path.join(
 )
 
 USE_UNROUNDED_AREA_COORDS = False
+SOURCE_CDS = False
 
 
 def main(download=False, compute_stats=True, use_cache=True):
@@ -63,6 +64,7 @@ def main(download=False, compute_stats=True, use_cache=True):
             # resolution=0.05,
             all_touched=False,
             use_cache=use_cache,
+            source_cds=SOURCE_CDS,
             use_unrounded_area_coords=USE_UNROUNDED_AREA_COORDS,
             # date_list=[d.strftime("%Y-%m-%d") for d in
             #            pd.date_range(start='2000-01-01',


### PR DESCRIPTION
Expanded `get_ecmwf_forecast` methods to also get the ECMWF API version. Lots of hard-coded stuff which is bad because presumably this will all be migrated soon.